### PR TITLE
Allow (forward) slashes in image names

### DIFF
--- a/src/backend/routes/api/repos.js
+++ b/src/backend/routes/api/repos.js
@@ -52,7 +52,7 @@ router
  * /api/repos/abc123
  */
 router
-    .route('/:name')
+    .route('/:name([a-z/]+)')
     .options((req, res) => {
         res.sendStatus(204);
     })

--- a/src/frontend/js/router.js
+++ b/src/frontend/js/router.js
@@ -28,6 +28,7 @@ export default (state, actions) => {
             return div(
                 Route({path: '/', render: ImagesRoute(state, actions)}),
                 Route({path: '/image/:imageId', render: ImageRoute(state, actions)}),
+                Route({path: '/image/:imageDomain/:imageId', render: ImageRoute(state, actions)}),
                 Route({path: '/instructions/pushing', render: PushingRoute(state, actions)}),
                 Route({path: '/instructions/pulling', render: PullingRoute(state, actions)}),
                 Route({path: '/instructions/deleting', render: DeletingRoute(state, actions)})

--- a/src/frontend/js/routes/image.js
+++ b/src/frontend/js/routes/image.js
@@ -15,6 +15,10 @@ export default (state, actions) => params => {
     let append_delete_model = false;
     let image               = null;
 
+    if (typeof params.match.params.imageDomain !== 'undefined' && params.match.params.imageDomain.length > 0) {
+      image_id = [params.match.params.imageDomain, image_id].join('/');
+    }
+
     // if image doesn't exist in state: refresh
     if (typeof state.images[image_id] === 'undefined' || !state.images[image_id]) {
         refresh = true;


### PR DESCRIPTION
Fix for #3 

I was not able to make the changes to frontend/router.js cleaner. I just added a second line with a slash to allow the slashes in the image name. On the image page I just join the two params.

The router changes for the backend are a lot nicer ;)