### PR TITLE
Bugfix: Allow hyphen in image names

### DIFF
--- a/src/backend/routes/api/repos.js
+++ b/src/backend/routes/api/repos.js
@@ -52,7 +52,7 @@ router
  * /api/repos/abc123
  */
 router
-    .route('/:name([a-z/]+)')
+    .route('/:name([-a-zA-Z0-9/]+)')
     .options((req, res) => {
         res.sendStatus(204);
     })


### PR DESCRIPTION
Main problem was dashes not working in the API. Updated the regex to fix this.