### PR TITLE
Fix docker path and cron job to run docker gc

### DIFF
--- a/src/frontend/js/routes/instructions/deleting.js
+++ b/src/frontend/js/routes/instructions/deleting.js
@@ -33,7 +33,7 @@ export default (state, actions) => params => div(
                     ),
                     p('And if you wanted to make a cron job that runs every 30 mins:'),
                     pre(
-                        code('0,30 * * * * /bin/docker exec -it my-registry bin/registry garbage-collect /etc/docker/registry/config.yml >> /dev/null 2>&1')
+                        code('0,30 * * * * /usr/bin/docker exec -i my-registry bin/registry garbage-collect /etc/docker/registry/config.yml >> /dev/null 2>&1')
                     )
                 ])
             ])


### PR DESCRIPTION
- Added prefix to docker call to use /usr/bin in place of /bin

- Removes the 't' flag when calling the docker command as cron doesn't
  run on a tty and that was making the command to throw an error.