### PR TITLE
Docker secrets compatible (blatantly stolen from mysql5.7 entrypoint.sh)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,11 @@ ADD LICENCE             /app/LICENCE
 ADD package.json        /app/package.json
 ADD src/backend         /app/src/backend
 
+COPY load_secrets.sh /usr/local/bin/
+
 WORKDIR /app
 
-CMD node --max_old_space_size=250 --abort_on_uncaught_exception src/backend/index.js
+CMD load_secrets.sh && node --max_old_space_size=250 --abort_on_uncaught_exception src/backend/index.js
 
 HEALTHCHECK --interval=15s --timeout=3s CMD curl -f http://localhost/ || exit 1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
 FROM jc21/node:latest
 
-MAINTAINER Jamie Curnow <jc@jc21.com>
 LABEL maintainer="Jamie Curnow <jc@jc21.com>"
 
 RUN apt-get update \

--- a/load_secrets.sh
+++ b/load_secrets.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -eo pipefail
+shopt -s nullglob
+
+log() {
+	local type="$1"; shift
+	printf '%s [%s] [CMD]: %s\n' "$(date --rfc-3339=seconds)" "$type" "$*"
+  
+error() {
+	log ERROR "$@" >&2
+	exit 1
+}
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_REGISTRY_PASS' 'example'
+# (will allow for "$XYZ_REGISTRY_PASS_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		mysql_error "Both $var and $fileVar are set (but are exclusive)"
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# Initialize values that might be stored in a file
+	file_env 'REGISTRY_HOST' '%'
+	file_env 'REGISTRY_SSL'
+	file_env 'REGISTRY_DOMAIN'
+	file_env 'REGISTRY_STORAGE_DELETE_ENABLED'
+	file_env 'REGISTRY_USER'
+  file_env 'REGISTRY_PASS'

--- a/load_secrets.sh
+++ b/load_secrets.sh
@@ -5,6 +5,7 @@ shopt -s nullglob
 log() {
 	local type="$1"; shift
 	printf '%s [%s] [CMD]: %s\n' "$(date --rfc-3339=seconds)" "$type" "$*"
+}
   
 error() {
 	log ERROR "$@" >&2
@@ -33,9 +34,13 @@ file_env() {
 }
 
 # Initialize values that might be stored in a file
+docker_setup_env() {
 	file_env 'REGISTRY_HOST' '%'
 	file_env 'REGISTRY_SSL'
 	file_env 'REGISTRY_DOMAIN'
 	file_env 'REGISTRY_STORAGE_DELETE_ENABLED'
 	file_env 'REGISTRY_USER'
-  file_env 'REGISTRY_PASS'
+	file_env 'REGISTRY_PASS'
+}
+
+docker_setup_env;

--- a/package.json
+++ b/package.json
@@ -20,12 +20,12 @@
         "signale": "^1.2.1"
     },
     "devDependencies": {
+        "@hyperapp/html": "git+https://github.com/maxholman/hyperapp-html.git#5bde674d42c87bb8191f8cc11a8a3c7d334e3dfb",
         "babel-core": "^6.26.3",
         "babel-loader": "^7.1.4",
         "babel-minify-webpack-plugin": "^0.3.1",
-        "babel-preset-env": "^1.7.0",
-        "@hyperapp/html": "git+https://github.com/maxholman/hyperapp-html.git#5bde674d42c87bb8191f8cc11a8a3c7d334e3dfb",
         "babel-plugin-transform-react-jsx": "^6.24.1",
+        "babel-preset-env": "^1.7.0",
         "copy-webpack-plugin": "^4.5.4",
         "css-loader": "^1.0.0",
         "file-loader": "^2.0.0",


### PR DESCRIPTION
Tested successfully on my local testing swarm.

you can now use secrets and avoid leaking passwords by reading ENV variables.

```yaml
environment:
    - REGISTRY_PASS_FILE=/run/secrets/MYSECRET
```
